### PR TITLE
Arrow safe refactoring

### DIFF
--- a/examples/dummy-opencv-capture/main.rs
+++ b/examples/dummy-opencv-capture/main.rs
@@ -5,7 +5,7 @@ use fastformat::image::Image;
 fn camera_read() -> ndarray::Array<u8, ndarray::Ix3> {
     // Dummy camera read
 
-    let flat_image = vec![0; 27];
+    let flat_image = (110..137).collect::<Vec<u8>>();
     println!(
         "Generate a camera image at address: {:?}",
         flat_image.as_ptr()
@@ -16,10 +16,10 @@ fn camera_read() -> ndarray::Array<u8, ndarray::Ix3> {
     return image.bgr8_into_ndarray().unwrap();
 }
 
-fn image_show(_frame: ndarray::ArrayView<u8, ndarray::Ix3>) {
+fn image_show(frame: ndarray::ArrayView<u8, ndarray::Ix3>) {
     // Dummy image show
 
-    println!("Showing an image.");
+    println!("{:?}", frame);
 }
 
 fn send_output(arrow_array: arrow::array::UnionArray) {

--- a/src/bbox.rs
+++ b/src/bbox.rs
@@ -16,19 +16,19 @@ pub struct BBox {
     pub encoding: Encoding,
 }
 
-type BboxNdArrayResult = (
+type BBoxNDArrayResult = (
     ndarray::Array<f32, ndarray::Ix1>,
     ndarray::Array<f32, ndarray::Ix1>,
     ndarray::Array<String, ndarray::Ix1>,
 );
 
-type BboxNdArrayViewResult<'a> = (
+type BBoxNDArrayViewResult<'a> = (
     ndarray::ArrayView<'a, f32, ndarray::Ix1>,
     ndarray::ArrayView<'a, f32, ndarray::Ix1>,
     ndarray::ArrayView<'a, String, ndarray::Ix1>,
 );
 
-type BboxNdArrayViewMutResult<'a> = (
+type BBoxNDArrayViewMutResult<'a> = (
     ndarray::ArrayViewMut<'a, f32, ndarray::Ix1>,
     ndarray::ArrayViewMut<'a, f32, ndarray::Ix1>,
     ndarray::ArrayViewMut<'a, String, ndarray::Ix1>,

--- a/src/bbox.rs
+++ b/src/bbox.rs
@@ -16,6 +16,24 @@ pub struct BBox {
     pub encoding: Encoding,
 }
 
+type BboxNdArrayResult = (
+    ndarray::Array<f32, ndarray::Ix1>,
+    ndarray::Array<f32, ndarray::Ix1>,
+    ndarray::Array<String, ndarray::Ix1>,
+);
+
+type BboxNdArrayViewResult<'a> = (
+    ndarray::ArrayView<'a, f32, ndarray::Ix1>,
+    ndarray::ArrayView<'a, f32, ndarray::Ix1>,
+    ndarray::ArrayView<'a, String, ndarray::Ix1>,
+);
+
+type BboxNdArrayViewMutResult<'a> = (
+    ndarray::ArrayViewMut<'a, f32, ndarray::Ix1>,
+    ndarray::ArrayViewMut<'a, f32, ndarray::Ix1>,
+    ndarray::ArrayViewMut<'a, String, ndarray::Ix1>,
+);
+
 impl BBox {
     pub fn into_xyxy(self) -> Result<Self> {
         match self.encoding {

--- a/src/bbox.rs
+++ b/src/bbox.rs
@@ -16,19 +16,19 @@ pub struct BBox {
     pub encoding: Encoding,
 }
 
-type BBoxNDArrayResult = (
+type BBoxArrayResult = (
     ndarray::Array<f32, ndarray::Ix1>,
     ndarray::Array<f32, ndarray::Ix1>,
     ndarray::Array<String, ndarray::Ix1>,
 );
 
-type BBoxNDArrayViewResult<'a> = (
+type BBoxArrayViewResult<'a> = (
     ndarray::ArrayView<'a, f32, ndarray::Ix1>,
     ndarray::ArrayView<'a, f32, ndarray::Ix1>,
     ndarray::ArrayView<'a, String, ndarray::Ix1>,
 );
 
-type BBoxNDArrayViewMutResult<'a> = (
+type BBoxArrayViewMutResult<'a> = (
     ndarray::ArrayViewMut<'a, f32, ndarray::Ix1>,
     ndarray::ArrayViewMut<'a, f32, ndarray::Ix1>,
     ndarray::ArrayViewMut<'a, String, ndarray::Ix1>,

--- a/src/bbox/encoding.rs
+++ b/src/bbox/encoding.rs
@@ -2,6 +2,7 @@ use eyre::{Report, Result};
 
 use std::fmt::Display;
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy)]
 pub enum Encoding {
     XYXY,

--- a/src/bbox/xywh.rs
+++ b/src/bbox/xywh.rs
@@ -1,5 +1,5 @@
 use super::{
-    encoding::Encoding, BBox, BboxNdArrayResult, BboxNdArrayViewMutResult, BboxNdArrayViewResult,
+    encoding::Encoding, BBox, BBoxNDArrayResult, BBoxNDArrayViewMutResult, BBoxNDArrayViewResult,
 };
 use eyre::{Context, Report, Result};
 
@@ -34,7 +34,7 @@ impl BBox {
         )
     }
 
-    pub fn xywh_into_ndarray(self) -> Result<BboxNdArrayResult> {
+    pub fn xywh_into_ndarray(self) -> Result<BBoxNDArrayResult> {
         match self.encoding {
             Encoding::XYWH => Ok((
                 ndarray::Array::from_vec(self.data),
@@ -45,7 +45,7 @@ impl BBox {
         }
     }
 
-    pub fn xywh_into_ndarray_view(&self) -> Result<BboxNdArrayViewResult> {
+    pub fn xywh_into_ndarray_view(&self) -> Result<BBoxNDArrayViewResult> {
         match self.encoding {
             Encoding::XYWH => {
                 let data = ndarray::ArrayView::from_shape(self.data.len(), &self.data)
@@ -62,7 +62,7 @@ impl BBox {
         }
     }
 
-    pub fn xywh_into_ndarray_view_mut(&mut self) -> Result<BboxNdArrayViewMutResult> {
+    pub fn xywh_into_ndarray_view_mut(&mut self) -> Result<BBoxNDArrayViewMutResult> {
         match self.encoding {
             Encoding::XYWH => {
                 let data = ndarray::ArrayViewMut::from_shape(self.data.len(), &mut self.data)

--- a/src/bbox/xywh.rs
+++ b/src/bbox/xywh.rs
@@ -1,5 +1,5 @@
 use super::{
-    encoding::Encoding, BBox, BBoxNDArrayResult, BBoxNDArrayViewMutResult, BBoxNDArrayViewResult,
+    encoding::Encoding, BBox, BBoxArrayResult, BBoxArrayViewMutResult, BBoxArrayViewResult,
 };
 use eyre::{Context, Report, Result};
 
@@ -34,7 +34,7 @@ impl BBox {
         )
     }
 
-    pub fn xywh_into_ndarray(self) -> Result<BBoxNDArrayResult> {
+    pub fn xywh_into_ndarray(self) -> Result<BBoxArrayResult> {
         match self.encoding {
             Encoding::XYWH => Ok((
                 ndarray::Array::from_vec(self.data),
@@ -45,7 +45,7 @@ impl BBox {
         }
     }
 
-    pub fn xywh_into_ndarray_view(&self) -> Result<BBoxNDArrayViewResult> {
+    pub fn xywh_into_ndarray_view(&self) -> Result<BBoxArrayViewResult> {
         match self.encoding {
             Encoding::XYWH => {
                 let data = ndarray::ArrayView::from_shape(self.data.len(), &self.data)
@@ -62,7 +62,7 @@ impl BBox {
         }
     }
 
-    pub fn xywh_into_ndarray_view_mut(&mut self) -> Result<BBoxNDArrayViewMutResult> {
+    pub fn xywh_into_ndarray_view_mut(&mut self) -> Result<BBoxArrayViewMutResult> {
         match self.encoding {
             Encoding::XYWH => {
                 let data = ndarray::ArrayViewMut::from_shape(self.data.len(), &mut self.data)

--- a/src/bbox/xywh.rs
+++ b/src/bbox/xywh.rs
@@ -1,4 +1,6 @@
-use super::{encoding::Encoding, BBox};
+use super::{
+    encoding::Encoding, BBox, BboxNdArrayResult, BboxNdArrayViewMutResult, BboxNdArrayViewResult,
+};
 use eyre::{Context, Report, Result};
 
 impl BBox {
@@ -32,13 +34,7 @@ impl BBox {
         )
     }
 
-    pub fn xywh_into_ndarray(
-        self,
-    ) -> Result<(
-        ndarray::Array<f32, ndarray::Ix1>,
-        ndarray::Array<f32, ndarray::Ix1>,
-        ndarray::Array<String, ndarray::Ix1>,
-    )> {
+    pub fn xywh_into_ndarray(self) -> Result<BboxNdArrayResult> {
         match self.encoding {
             Encoding::XYWH => Ok((
                 ndarray::Array::from_vec(self.data),
@@ -49,13 +45,7 @@ impl BBox {
         }
     }
 
-    pub fn xywh_into_ndarray_view(
-        &self,
-    ) -> Result<(
-        ndarray::ArrayView<f32, ndarray::Ix1>,
-        ndarray::ArrayView<f32, ndarray::Ix1>,
-        ndarray::ArrayView<String, ndarray::Ix1>,
-    )> {
+    pub fn xywh_into_ndarray_view(&self) -> Result<BboxNdArrayViewResult> {
         match self.encoding {
             Encoding::XYWH => {
                 let data = ndarray::ArrayView::from_shape(self.data.len(), &self.data)
@@ -72,13 +62,7 @@ impl BBox {
         }
     }
 
-    pub fn xywh_into_ndarray_view_mut(
-        &mut self,
-    ) -> Result<(
-        ndarray::ArrayViewMut<f32, ndarray::Ix1>,
-        ndarray::ArrayViewMut<f32, ndarray::Ix1>,
-        ndarray::ArrayViewMut<String, ndarray::Ix1>,
-    )> {
+    pub fn xywh_into_ndarray_view_mut(&mut self) -> Result<BboxNdArrayViewMutResult> {
         match self.encoding {
             Encoding::XYWH => {
                 let data = ndarray::ArrayViewMut::from_shape(self.data.len(), &mut self.data)

--- a/src/bbox/xyxy.rs
+++ b/src/bbox/xyxy.rs
@@ -1,4 +1,6 @@
-use super::{encoding::Encoding, BBox};
+use super::{
+    encoding::Encoding, BBox, BboxNdArrayResult, BboxNdArrayViewMutResult, BboxNdArrayViewResult,
+};
 use eyre::{Context, Report, Result};
 
 impl BBox {
@@ -29,13 +31,7 @@ impl BBox {
         )
     }
 
-    pub fn xyxy_into_ndarray(
-        self,
-    ) -> Result<(
-        ndarray::Array<f32, ndarray::Ix1>,
-        ndarray::Array<f32, ndarray::Ix1>,
-        ndarray::Array<String, ndarray::Ix1>,
-    )> {
+    pub fn xyxy_into_ndarray(self) -> Result<BboxNdArrayResult> {
         match self.encoding {
             Encoding::XYXY => Ok((
                 ndarray::Array::from_vec(self.data),
@@ -46,13 +42,7 @@ impl BBox {
         }
     }
 
-    pub fn xyxy_into_ndarray_view(
-        &self,
-    ) -> Result<(
-        ndarray::ArrayView<f32, ndarray::Ix1>,
-        ndarray::ArrayView<f32, ndarray::Ix1>,
-        ndarray::ArrayView<String, ndarray::Ix1>,
-    )> {
+    pub fn xyxy_into_ndarray_view(&self) -> Result<BboxNdArrayViewResult> {
         match self.encoding {
             Encoding::XYXY => {
                 let data = ndarray::ArrayView::from_shape(self.data.len(), &self.data)
@@ -69,13 +59,7 @@ impl BBox {
         }
     }
 
-    pub fn xyxy_into_ndarray_view_mut(
-        &mut self,
-    ) -> Result<(
-        ndarray::ArrayViewMut<f32, ndarray::Ix1>,
-        ndarray::ArrayViewMut<f32, ndarray::Ix1>,
-        ndarray::ArrayViewMut<String, ndarray::Ix1>,
-    )> {
+    pub fn xyxy_into_ndarray_view_mut(&mut self) -> Result<BboxNdArrayViewMutResult> {
         match self.encoding {
             Encoding::XYXY => {
                 let data = ndarray::ArrayViewMut::from_shape(self.data.len(), &mut self.data)

--- a/src/bbox/xyxy.rs
+++ b/src/bbox/xyxy.rs
@@ -1,5 +1,5 @@
 use super::{
-    encoding::Encoding, BBox, BboxNdArrayResult, BboxNdArrayViewMutResult, BboxNdArrayViewResult,
+    encoding::Encoding, BBox, BBoxNDArrayResult, BBoxNDArrayViewMutResult, BBoxNDArrayViewResult,
 };
 use eyre::{Context, Report, Result};
 
@@ -31,7 +31,7 @@ impl BBox {
         )
     }
 
-    pub fn xyxy_into_ndarray(self) -> Result<BboxNdArrayResult> {
+    pub fn xyxy_into_ndarray(self) -> Result<BBoxNDArrayResult> {
         match self.encoding {
             Encoding::XYXY => Ok((
                 ndarray::Array::from_vec(self.data),
@@ -42,7 +42,7 @@ impl BBox {
         }
     }
 
-    pub fn xyxy_into_ndarray_view(&self) -> Result<BboxNdArrayViewResult> {
+    pub fn xyxy_into_ndarray_view(&self) -> Result<BBoxNDArrayViewResult> {
         match self.encoding {
             Encoding::XYXY => {
                 let data = ndarray::ArrayView::from_shape(self.data.len(), &self.data)
@@ -59,7 +59,7 @@ impl BBox {
         }
     }
 
-    pub fn xyxy_into_ndarray_view_mut(&mut self) -> Result<BboxNdArrayViewMutResult> {
+    pub fn xyxy_into_ndarray_view_mut(&mut self) -> Result<BBoxNDArrayViewMutResult> {
         match self.encoding {
             Encoding::XYXY => {
                 let data = ndarray::ArrayViewMut::from_shape(self.data.len(), &mut self.data)

--- a/src/bbox/xyxy.rs
+++ b/src/bbox/xyxy.rs
@@ -1,5 +1,5 @@
 use super::{
-    encoding::Encoding, BBox, BBoxNDArrayResult, BBoxNDArrayViewMutResult, BBoxNDArrayViewResult,
+    encoding::Encoding, BBox, BBoxArrayResult, BBoxArrayViewMutResult, BBoxArrayViewResult,
 };
 use eyre::{Context, Report, Result};
 
@@ -31,7 +31,7 @@ impl BBox {
         )
     }
 
-    pub fn xyxy_into_ndarray(self) -> Result<BBoxNDArrayResult> {
+    pub fn xyxy_into_ndarray(self) -> Result<BBoxArrayResult> {
         match self.encoding {
             Encoding::XYXY => Ok((
                 ndarray::Array::from_vec(self.data),
@@ -42,7 +42,7 @@ impl BBox {
         }
     }
 
-    pub fn xyxy_into_ndarray_view(&self) -> Result<BBoxNDArrayViewResult> {
+    pub fn xyxy_into_ndarray_view(&self) -> Result<BBoxArrayViewResult> {
         match self.encoding {
             Encoding::XYXY => {
                 let data = ndarray::ArrayView::from_shape(self.data.len(), &self.data)
@@ -59,7 +59,7 @@ impl BBox {
         }
     }
 
-    pub fn xyxy_into_ndarray_view_mut(&mut self) -> Result<BBoxNDArrayViewMutResult> {
+    pub fn xyxy_into_ndarray_view_mut(&mut self) -> Result<BBoxArrayViewMutResult> {
         match self.encoding {
             Encoding::XYXY => {
                 let data = ndarray::ArrayViewMut::from_shape(self.data.len(), &mut self.data)


### PR DESCRIPTION
# Objective

Hi! I was adding other datatypes in the `other_datatype` branch, and after discussing with Marc Perlade <https://github.com/Ar3sion> <https://git.eleves.ens.fr/mperlade>, a student at ENS PSL, we found a safer way to retrieve data from the `arrow::UnionArray` than the previous method. So, I rewrote the Arrow part and achieved a really neat result!

# Changes

If you want to convert an Arrow object into an Image, you can simply get the UnionArray, convert it into a HashMap, and then extract the fields as `Vec<T>`.

```Rust
pub fn from_arrow(array: arrow::array::UnionArray) -> Result<Self> {
    let mut map = arrow_union_into_map(array)?;

    let width =
        get_primitive_array_from_map::<u32, arrow::datatypes::UInt32Type>("width", &mut map)?
            .first();
    let name = get_utf8_array_from_map("name", &mut map)?
        .first();
}
```

# Code

Everything is safe!

```Rust
// Convert an ArrowUnion to a HashMap
pub fn arrow_union_into_map(
    array: arrow::array::UnionArray,
) -> Result<HashMap<String, arrow::array::ArrayRef>> {
    let mut result = HashMap::new();

    let (union_fields, _, _, children) = array.into_parts();

    for (a, b) in union_fields.iter() {
        let child = children
            .get(a as usize)
            .ok_or_eyre(Report::msg(
                "Invalid union array field index. Must be >= 0 and correspond to the children index in the array.",
            ))?
            .clone();

        result.insert(b.name().to_string(), child);
    }

    Ok(result)
}

// Extract a Primitive Array without copying by consuming the `Arc<dyn Array>`
pub fn get_primitive_array_from_map<
    T: arrow::datatypes::ArrowNativeType,
    G: arrow::datatypes::ArrowPrimitiveType,
>(
    field: &str,
    map: &mut HashMap<String, arrow::array::ArrayRef>,
) -> Result<Vec<T>> {
    use arrow::array::Array;

    let array_data = map
        .remove(field)
        .ok_or_eyre(Report::msg("Invalid field for this map."))?
        .into_data();

    let array = arrow::array::PrimitiveArray::<G>::from(array_data);
    let (_, buffer, _) = array.into_parts();
    let buffer = buffer.into_inner();

    match buffer.into_vec::<T>() {
        Ok(vec) => Ok(vec),
        Err(e) => Err(Report::msg(format!(
            "T is not a valid type for this buffer. It must have the same layout as the buffer (this usually occurs when the type is incorrect or when another reference exists). Error: {:?}", e
        ))),
    }
}

// Extract a UTF8 String Array with only ONE copy per string, by consuming the `Arc<dyn Array>`
pub fn get_utf8_array_from_map(
    field: &str,
    map: &mut HashMap<String, arrow::array::ArrayRef>,
) -> Result<Vec<String>> {
    use arrow::array::Array;

    let array_data = map
        .remove(field)
        .ok_or_eyre(Report::msg("Invalid field for this map."))?
        .into_data();

    let array = arrow::array::StringArray::from(array_data);
    let (offsets, buffer, _) = array.into_parts();

    let slice = buffer.as_slice();
    let mut last_offset = 0;
    let mut iterator = offsets.iter();
    iterator.next();

    iterator
        .map(|&offset| {
            let offset = offset as usize;
            let slice = &slice[last_offset..offset];
            last_offset = offset;

            String::from_utf8(slice.to_vec()).wrap_err(Report::msg("Array is not UTF-8 encoded."))
        })
        .collect::<Result<Vec<String>>>()
}
```

# Acknowledgments

I really want to thank Marc Perlade for his help. He’s not into sharing his work on GitHub/GitLab, but he is fantastic.